### PR TITLE
Added interpunct

### DIFF
--- a/Latinational.keylayout
+++ b/Latinational.keylayout
@@ -497,7 +497,7 @@
             <key code="4" output="Ó"/>
             <key code="5" output="˝"/>
             <key code="6" output="¸"/>
-            <key code="7" output="˛"/>
+            <key code="7" output="·"/>
             <key code="8" output="Ç"/>
             <key code="9" output="◊"/>
             <key code="10" output="±"/>


### PR DESCRIPTION
swapped glyphs: "reversed" cedilla or ogonek (¸) for interpunct (·)